### PR TITLE
修复TwoTextureFilter用在texture target为OES的时候显示异常的情况

### DIFF
--- a/canvasgl/src/main/java/com/chillingvan/canvasgl/textureFilter/TwoTextureFilter.java
+++ b/canvasgl/src/main/java/com/chillingvan/canvasgl/textureFilter/TwoTextureFilter.java
@@ -105,4 +105,8 @@ public abstract class TwoTextureFilter extends BasicTextureFilter {
         GLES20Canvas.checkError();
     }
 
+    @Override
+    public String getOesFragmentProgram() {
+        return "#extension GL_OES_EGL_image_external : require\n" + getFragmentShader().replaceFirst(SAMPLER_2D, SAMPLER_EXTERNAL_OES);
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,37 +1,18 @@
+## Project-wide Gradle settings.
 #
-# /*
-#  *
-#  *  * Copyright (C) 2016 ChillingVan
-#  *  *
-#  *  * Licensed under the Apache License, Version 2.0 (the "License");
-#  *  * you may not use this file except in compliance with the License.
-#  *  * You may obtain a copy of the License at
-#  *  *
-#  *  * http://www.apache.org/licenses/LICENSE-2.0
-#  *  *
-#  *  * Unless required by applicable law or agreed to in writing, software
-#  *  * distributed under the License is distributed on an "AS IS" BASIS,
-#  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  *  * See the License for the specific language governing permissions and
-#  *  * limitations under the License.
-#  *
-#  */
-#
-
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+#Fri Jul 21 09:41:36 CST 2017
+systemProp.http.proxyHost=127.0.0.1
+org.gradle.jvmargs=-Xmx1536m
+systemProp.http.proxyPort=1080

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,37 @@
-## Project-wide Gradle settings.
 #
+# /*
+#  *
+#  *  * Copyright (C) 2016 ChillingVan
+#  *  *
+#  *  * Licensed under the Apache License, Version 2.0 (the "License");
+#  *  * you may not use this file except in compliance with the License.
+#  *  * You may obtain a copy of the License at
+#  *  *
+#  *  * http://www.apache.org/licenses/LICENSE-2.0
+#  *  *
+#  *  * Unless required by applicable law or agreed to in writing, software
+#  *  * distributed under the License is distributed on an "AS IS" BASIS,
+#  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  *  * See the License for the specific language governing permissions and
+#  *  * limitations under the License.
+#  *
+#  */
+#
+
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-#
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx1024m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-#
+org.gradle.jvmargs=-Xmx1536m
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-#Fri Jul 21 09:41:36 CST 2017
-systemProp.http.proxyHost=127.0.0.1
-org.gradle.jvmargs=-Xmx1536m
-systemProp.http.proxyPort=1080


### PR DESCRIPTION
修复TwoTextureFilter用在texture target为OES的时候显示异常的情况
关键代码
```
@Override
    public String getOesFragmentProgram() {
        return "#extension GL_OES_EGL_image_external : require\n" + getFragmentShader().replaceFirst(SAMPLER_2D, SAMPLER_EXTERNAL_OES);
    }
```
